### PR TITLE
integrate kafka topic register

### DIFF
--- a/Aloha.EventBus.Kafka/KafkaEventBusExtensions.cs
+++ b/Aloha.EventBus.Kafka/KafkaEventBusExtensions.cs
@@ -42,7 +42,7 @@ public static class KafkaEventBusExtensions
         {
             settings.Config.GroupId = groupId;
             settings.Config.AutoOffsetReset = AutoOffsetReset.Earliest;
-            settings.Config.SecurityProtocol = SecurityProtocol.Plaintext; // Explicitly use non-SSL
+            //settings.Config.SecurityProtocol = SecurityProtocol.Plaintext; // Explicitly use non-SSL
         },
         configureBuilder: (builder) =>
         {

--- a/Aloha.MicroService.Post/Bootstraping/ApplicationServiceExtensions.cs
+++ b/Aloha.MicroService.Post/Bootstraping/ApplicationServiceExtensions.cs
@@ -92,5 +92,7 @@ namespace Aloha.MicroService.Post.Bootstraping
             builder.Services.AddDbContext<PostDbContext>(options =>
                 options.UseNpgsql(connectionString));
         }
+
+
     }
 }

--- a/Aloha/Aloha.AppHost/Extensions/ExternalServiceRegistrationExtentions.cs
+++ b/Aloha/Aloha.AppHost/Extensions/ExternalServiceRegistrationExtentions.cs
@@ -4,6 +4,13 @@ namespace Aloha.AppHost.Extensions;
 
 public static class ApplicationServiceExtensions
 {
+
+    private static class Consts
+    {
+        public const string Env_EventPublishingTopics = "EVENT_PUBLISHING_TOPICS";
+        public const string Env_EventConsumingTopics = "EVENT_CONSUMING_TOPICS";
+    }
+
     public static IDistributedApplicationBuilder AddApplicationServices(this IDistributedApplicationBuilder builder)
     {
         var kafka = builder.AddKafka("kafka")
@@ -16,11 +23,23 @@ public static class ApplicationServiceExtensions
                         .WithKafkaUI();
         }
 
+        builder.Eventing.Subscribe<ResourceReadyEvent>(kafka.Resource, async (@event, ct) =>
+{
+    await CreateKafkaTopics(@event, kafka.Resource, ct);
+});
+
+
         var userService = builder.AddProjectWithPostfix<Projects.Aloha_MicroService_User>()
             .WithReference(kafka)
             .WaitFor(kafka);
 
         var postService = builder.AddProjectWithPostfix<Projects.Aloha_MicroService_Post>()
+        .WithEnvironment(Consts.Env_EventPublishingTopics, GetTopicName<Projects.Aloha_MicroService_Post>())
+            .WithEnvironment(Consts.Env_EventConsumingTopics,
+                string.Join(',',
+                    GetTopicName<Projects.Aloha_MicroService_User>(),
+                    GetTopicName<Projects.Aloha_MicroService_Location>()
+                ))
             .WithReference(userService)
             .WithReference(kafka)
             .WaitFor(kafka);
@@ -37,4 +56,34 @@ public static class ApplicationServiceExtensions
 
         return builder;
     }
+
+    private static async Task CreateKafkaTopics(ResourceReadyEvent @event, KafkaServerResource kafkaResource, CancellationToken ct)
+    {
+        var logger = @event.Services.GetRequiredService<ILogger<Program>>();
+
+        TopicSpecification[] topics = [
+            new() { Name = GetTopicName<Projects.Aloha_MicroService_Post>(), NumPartitions = 1, ReplicationFactor = 1 },
+            new() { Name = GetTopicName<Projects.Aloha_MicroService_User>(), NumPartitions = 1, ReplicationFactor = 1 },
+        ];
+
+        logger.LogInformation("Creating topics: {topics} ...", string.Join(", ", topics.Select(t => t.Name).ToArray()));
+
+        var connectionString = await kafkaResource.ConnectionStringExpression.GetValueAsync(ct);
+        using var adminClient = new AdminClientBuilder(new AdminClientConfig()
+        {
+            BootstrapServers = connectionString,
+        }).Build();
+        try
+        {
+            await adminClient.CreateTopicsAsync(topics, new CreateTopicsOptions() { });
+        }
+        catch (CreateTopicsException ex)
+        {
+            logger.LogError(ex, "An error occurred creating topics");
+        }
+    }
+
+    private static string GetTopicName<TProject>(string postfix = "") => $"{typeof(TProject).Name.Replace('_', '-')}{(string.IsNullOrEmpty(postfix) ? "" : $"-{postfix}")}";
+
+
 }

--- a/Aloha/Aloha.AppHost/GlobalUsing.cs
+++ b/Aloha/Aloha.AppHost/GlobalUsing.cs
@@ -1,0 +1,5 @@
+﻿global using Confluent.Kafka;
+global using Confluent.Kafka.Admin;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
This pull request introduces several changes to enhance Kafka integration, improve event handling, and streamline service configuration in the `Aloha` project. The most significant updates include adding support for Kafka topic creation, defining constants for environment variables, and updating global imports to simplify dependencies.

### Kafka Integration Enhancements:
* Added a method `CreateKafkaTopics` in `ExternalServiceRegistrationExtentions.cs` to programmatically create Kafka topics during resource readiness events. This includes logging and error handling for topic creation.
* Updated the `AddApplicationServices` method to include Kafka-related environment variables (`EVENT_PUBLISHING_TOPICS` and `EVENT_CONSUMING_TOPICS`) and configured topic names dynamically based on project types.

### Code Organization Improvements:
* Introduced a `Consts` class in `ExternalServiceRegistrationExtentions.cs` to centralize environment variable names for better maintainability.
* Added global imports for Kafka and logging libraries in `GlobalUsing.cs` to reduce redundant `using` statements across files.

### Minor Updates:
* Commented out the explicit use of non-SSL `SecurityProtocol.Plaintext` in `KafkaEventBusExtensions.cs` to prepare for potential SSL configuration.
* Added blank lines in `ApplicationServiceExtensions.cs` for improved readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced application service registration to include automatic Kafka topic management for Post and User microservices.
  - Environment variables for event publishing and consuming topics are now set during Post microservice registration.

- **Chores**
  - Introduced global using directives for Kafka, dependency injection, and logging namespaces to streamline codebase imports.

- **Style**
  - Minor formatting adjustment in the database connection configuration for improved readability.

- **Refactor**
  - Kafka consumer configuration no longer forcibly sets the security protocol to plaintext.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->