### PR TITLE
refactor(AppHost): Add Aloha.Shared reference and refactor constants

### DIFF
--- a/Aloha/Aloha.AppHost/Aloha.AppHost.csproj
+++ b/Aloha/Aloha.AppHost/Aloha.AppHost.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\Aloha.MicroService.Plan\Aloha.MicroService.Plan.csproj" />
     <ProjectReference Include="..\..\Aloha.MicroService.Payment\Aloha.MicroService.Payment.csproj" />
     <ProjectReference Include="..\..\Aloha.MicroService.Post\Aloha.MicroService.Post.csproj" />
+    <ProjectReference Include="..\..\Aloha.Shared\Aloha.Shared.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\Aloha.UserService\Aloha.MicroService.User.csproj" />
   </ItemGroup>
 

--- a/Aloha/Aloha.AppHost/Extensions/ResourceExtensions.cs
+++ b/Aloha/Aloha.AppHost/Extensions/ResourceExtensions.cs
@@ -1,11 +1,6 @@
 ﻿namespace Aloha.AppHost.Extensions;
 public static class ResourceExtensions
 {
-    private static class Consts
-    {
-        public const string Env_EventPublishingTopics = "EVENT_PUBLISHING_TOPICS";
-        public const string Env_EventConsumingTopics = "EVENT_CONSUMING_TOPICS";
-    }
     public static IResourceBuilder<PostgresDatabaseResource> AddDefaultDatabase<TProject>(this IResourceBuilder<PostgresServerResource> builder)
     {
         return builder.AddDatabase($"{typeof(TProject).Name.Replace('_', '-')}-db");

--- a/Aloha/Aloha.AppHost/GlobalUsing.cs
+++ b/Aloha/Aloha.AppHost/GlobalUsing.cs
@@ -2,3 +2,4 @@
 global using Confluent.Kafka.Admin;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
+global using Aloha.Shared;


### PR DESCRIPTION
- Added project reference to `Aloha.Shared.csproj` in `Aloha.AppHost.csproj`.
- Removed the `Consts` class from `ResourceExtensions.cs`, eliminating unused constants for event topics.
- Introduced a global using directive for `Aloha.Shared` in `GlobalUsing.cs` to streamline access to shared types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new project reference to shared components and updated global namespace usage.
- **Refactor**
  - Removed unused private constants from internal code to streamline maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->